### PR TITLE
Simple check for GPU usage

### DIFF
--- a/kill_hogs/kill_hogs.py
+++ b/kill_hogs/kill_hogs.py
@@ -124,6 +124,12 @@ def is_restricted(username: str, pattern: str = '^(?!root).*'):
 
 
 def proc_is_using_gpu(pid):
+    """
+    Check if a process is using the GPU using the nvidia-smi tool.
+
+    Args:
+        pid (int): process id of the process.
+    """
     global nvidia_smi_cache
     if not nvidia_smi_cache:
         nvidia_smi = subprocess.run('nvidia-smi --query-compute-apps=pid --format=csv,noheader', shell=True, stdout=subprocess.PIPE)

--- a/kill_hogs/kill_hogs.py
+++ b/kill_hogs/kill_hogs.py
@@ -216,8 +216,8 @@ def kill_hogs(config: dict,
                 except (psutil.NoSuchProcess, FileNotFoundError):
                     pass
             logging.info('\n'.join(message))
-#            send_message_to_terminals(proc.username(),
-#                                      config['terminal_warning'])
+            send_message_to_terminals(proc.username(),
+                                      config['terminal_warning'])
 
             if slack:
                 post_to_slack('\n'.join(message), config['slack_url'])

--- a/kill_hogs/kill_hogs.py
+++ b/kill_hogs/kill_hogs.py
@@ -113,7 +113,7 @@ def terminate(kill_list):
 def is_restricted(username: str, pattern: str = '^(?!root).*'):
     """
     Test if processes of username should be limited in their resources.
-    Bu default everybody except root is restricted. (this, of course, can be dangerous)
+    By default everybody except root is restricted. (this, of course, can be dangerous)
 
     Args:
         username (str): the username to test


### PR DESCRIPTION
This checks whether a process is using a GPU (by running nvidia-smi and checking the pid) and if so, sets a limit on the wall time of the process.

Note that it currently can't detect if a longer running process just started using the GPU, since nvidia-smi does not provide this information...